### PR TITLE
Make the lift macro work in functions

### DIFF
--- a/tests/macro.jl
+++ b/tests/macro.jl
@@ -22,3 +22,12 @@ push!(x, 3)
 @test l1.value == [x.value]
 @test l2.value == [x.value, y.value^2]
 @test c1.value ==  {x.value}
+
+# test use in a function
+k = 3
+f(x,y) = @lift x + y + 1 + k
+
+z = f(x,y)
+push!(x, 3)
+@test x.value^2 + x.value + 4 == z.value
+


### PR DESCRIPTION
The existing `@lift` macro won't work in functions or other places where the types are not known at macro evaluation time. This pull request delays the `eval` until runtime to determine which variables are Signals. Use of eval is normally frowned on and is not fast, but for this application, it seems suitable. Setting up Signals isn't normally performance critical. 