### PR TITLE
Include lift which works with non signals

### DIFF
--- a/src/Reactive.jl
+++ b/src/Reactive.jl
@@ -337,6 +337,12 @@ lift(f::Callable, output_type::Type, inputs::SignalSource...; kwargs...) =
 lift(f::Callable, inputs::SignalSource...; kwargs...) =
     lift(f, map(signal, inputs)...; kwargs...)
 
+makesignal(s::Signal) = s
+makesignal(v) = Input(v)
+function lift(f::Callable, inputs...)
+    lift(f, map(makesignal, inputs)...)
+end
+
 # Uncomment in Julia >= 0.3 to enable cute infix operators.
 #     ⟿(signals::(Any...), f::Callable) = lift(f, signals...)
 #     ⟿(signal, f::Callable) = lift(f, signal)


### PR DESCRIPTION
This is pretty convenient, if you don't want an anonymous function for every lift, that relies on a constant values.
Example:
```Julia
lift(+, some_array_signal, 1)
```
I'm not sure what the intended usage of `signal` is, but it would probably be better to overload it instead of using `makesignal`?

Best,
Simon