### PR TITLE
Record catch_backtrace earlier

### DIFF
--- a/src/Reactive.jl
+++ b/src/Reactive.jl
@@ -328,11 +328,12 @@ begin
                 isupdating = false
                 return nothing
             catch ex
+                bt = catch_backtrace()
                 # FIXME: Rethink this.
                 isupdating = false
                 showerror(STDERR, ex)
                 println(STDERR)
-                Base.show_backtrace(STDERR, catch_backtrace())
+                Base.show_backtrace(STDERR, bt)
                 println(STDERR)
                 throw(ex)
             end


### PR DESCRIPTION
If one of the called function throws, catch_backtrace, will no longer give the correct backtrace.
Unfortunately nowadays, this situation happens quite often because we throw so frequently in
type inference.

cc @JeffBezanson who may be interested in the failure mode