### PR TITLE
Permit gc on fps nodes

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -65,6 +65,7 @@ Base.show(io::IO, n::Node) =
     write(io, "Node{$(eltype(n))}($(n.value), nactions=$(length(n.actions))$(n.alive ? "" : ", closed"))")
 
 value(n::Node) = n.value
+value(::Void) = false
 eltype{T}(::Node{T}) = T
 eltype{T}(::Type{Node{T}}) = T
 
@@ -130,6 +131,7 @@ function _push!(n, x, onerror=print_error)
     end
     nothing
 end
+_push!(::Void, x, onerror=print_error) = nothing
 
 # remove messages from the channel and propagate them
 global run

--- a/src/time.jl
+++ b/src/time.jl
@@ -31,19 +31,16 @@ function every_connect(dt, output)
 end
 
 function setup_next_tick(outputref, switchref, dt, wait_dt)
-    weakrefdo(switchref, value, ()->false) && Timer(t -> begin
-        weakrefdo(switchref, value, ()->false) &&
-            weakrefdo(outputref, x -> push!(x, dt))
-    end, wait_dt)
-end
-
-function weakrefdo(ref, yes, no=()->nothing)
-    ref.value != nothing ? yes(ref.value) : no()
+    if value(switchref.value)
+        Timer(t -> if value(switchref.value)
+                       _push!(outputref, dt)
+                   end, wait_dt)
+    end
 end
 
 function fpswhen_connect(rate, switch, output)
-    let prev_time = time(),
-        dt = 1.0/rate,
+    let prev_time = time()
+        dt = 1.0/rate
         outputref = WeakRef(output)
         switchref = WeakRef(switch)
         switch_ticks = filter(x->x, false, switch) # only turn-ons
@@ -52,7 +49,7 @@ function fpswhen_connect(rate, switch, output)
         for inp in [output, switch_ticks]
             add_action!(inp, output) do output, timestep
                 start_time = time()
-                setup_next_tick(outputref, switchref, time()-prev_time, dt)
+                setup_next_tick(outputref, switchref, start_time-prev_time, dt)
                 prev_time = start_time
             end
         end


### PR DESCRIPTION
The tests don't pass, but hopefully you can fix that? This version seems to allow cleanup of fps-created nodes. As with #76, it's not really obvious to me why this works when the previous one didn't. But I at least find this version easier to read anyway, so hopefully this is a step forward.