### PR TITLE
Add explicit dependency on Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat


### PR DESCRIPTION
Pkg.test was only passing because FactCheck is in test/REQUIRE
and FactCheck happens to depend on Compat