### PR TITLE
Add option to specify type of throttle Signal

### DIFF
--- a/src/deprecation.jl
+++ b/src/deprecation.jl
@@ -10,4 +10,6 @@ export lift, consume, foldl, keepwhen, keepif, dropif, dropwhen
 @deprecate keepif filter
 @deprecate dropif(f, default, signal) filter(x -> !f(x), default, signal)
 @deprecate dropwhen(predicate, x, signal) filterwhen(map(!, predicate), x, signal)
-@deprecate call{T}(::Type{Signal{T}}, x) Signal(T, x)
+if VERSION < v"0.5.0-dev"
+    @deprecate call{T}(::Type{Signal{T}}, x) Signal(T, x)
+end

--- a/src/time.jl
+++ b/src/time.jl
@@ -12,8 +12,8 @@ For example
 will create vectors of updates to the integer signal `x` which occur within 0.2 second time windows.
 
 """
-function throttle{T}(dt, node::Signal{T}, f=(acc, x) -> x, init=value(node), reinit=x->x)
-    output = Signal(init, (node,))
+function throttle{T}(dt, node::Signal{T}, f=(acc,x)->x, init=value(node), reinit=x->x; typ=typeof(init))
+    output = Signal(typ, init, (node,))
     throttle_connect(dt, output, node, f, init, reinit)
     output
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -171,7 +171,7 @@ facts("Basic checks") do
     context("push! inside push!") do
         a = Signal(0)
         b = Signal(1)
-        map(x -> push!(a, x), b)
+        Reactive.preserve(map(x -> push!(a, x), b))
 
         @fact value(a) --> 0
 

--- a/test/call_count.jl
+++ b/test/call_count.jl
@@ -1,5 +1,7 @@
 
-number() = rand(0:100)
+if !isdefined(:number)
+    number() = rand(0:100)
+end
 
 facts("Call counting") do
     a = Signal(0)

--- a/test/time.jl
+++ b/test/time.jl
@@ -116,6 +116,17 @@ facts("Timing functions") do
         @fact value(y) --> 1
         @fact value(z′) --> 2
         @fact value(y′) --> Int[3,2,1]
+
+        # type safety
+        s1 = Signal(3)
+        s2 = Signal(rand(2,2))
+        m = merge(s1, s2)
+        t = throttle(1/60, m; typ=Any)
+        r = rand(3,3)
+        push!(s2, r)
+        Reactive.run(1)
+        sleep(0.05)
+        Reactive.run(1)
+        @fact value(t) --> r
     end
 end
-


### PR DESCRIPTION
As illustrated in the test, I discovered that `throttle` on a `merge`ed signal can run into trouble if the different signals have different types.

BTW, the CI failure is something that also happens for me locally on occasion. Seems like there might be some kind of race condition in that test?
